### PR TITLE
Fix Farsi translate for password help text.

### DIFF
--- a/django/contrib/auth/locale/fa/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/fa/LC_MESSAGES/django.po
@@ -250,19 +250,19 @@ msgstr[1] "رمز عبور شما می‌بایست حداقل از %(min_length
 msgid "The password is too similar to the %(verbose_name)s."
 msgstr "این رمز عبور بسیار شبیه %(verbose_name)s می‌باشد."
 
-msgid "Your password can't be too similar to your other personal information."
+msgid "Your password can’t be too similar to your other personal information."
 msgstr "رمز عبور شما نمی‌تواند شبیه سایر اطلاعات شخصی شما باشد."
 
 msgid "This password is too common."
 msgstr "این رمز عبور بسیار رایج است."
 
-msgid "Your password can't be a commonly used password."
+msgid "Your password can’t be a commonly used password."
 msgstr "رمز شما نمی تواند از عبارات معروف باشد."
 
 msgid "This password is entirely numeric."
 msgstr "رمز شما کلا عدد است"
 
-msgid "Your password can't be entirely numeric."
+msgid "Your password can’t be entirely numeric."
 msgstr "رمز شما نمی تواند کلا عدد باشد"
 
 #, python-format


### PR DESCRIPTION
3 help text could not be translated due to the inconsistency of the English text in the translation file with the original Django files (difference in one character).